### PR TITLE
relax pypdf constraints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ numpy = "^1.24.2"
 openpyxl = "^3.1.0"
 pandas = ">=1.5.3"
 pdfminer-six = ">=20221105"
-pypdf = "^3.4.0"
+pypdf = ">=3.17.0"
 tabulate = "^0.9.0"
 ghostscript = { optional = true, version = "^0.7" }
 opencv-python = { optional = true, version = "^4.7.0.68" }


### PR DESCRIPTION
relax pypdf constraints so we can upgrade pypdf to 4.x